### PR TITLE
Updated gem lockfile to work on Heroku.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,8 @@ GEM
     diff-lcs (1.3)
     erubi (1.6.1)
     execjs (2.7.0)
+    faraday (0.13.1)
+      multipart-post (>= 1.2, < 3)
     ffi (1.9.18)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
@@ -68,6 +70,8 @@ GEM
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
+    jwt (1.5.6)
+    libxml-ruby (3.0.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -83,6 +87,7 @@ GEM
     mini_portile2 (2.2.0)
     minitest (5.10.3)
     multi_json (1.12.1)
+    multipart-post (2.0.0)
     nio4r (2.1.0)
     nokogiri (1.8.0)
       mini_portile2 (~> 2.2.0)
@@ -170,6 +175,10 @@ GEM
     turbolinks (5.0.1)
       turbolinks-source (~> 5)
     turbolinks-source (5.0.3)
+    twilio-ruby (5.1.2)
+      faraday (~> 0.9)
+      jwt (~> 1.5)
+      libxml-ruby (= 3.0.0)
     tzinfo (1.2.3)
       thread_safe (~> 0.1)
     uglifier (3.2.0)
@@ -202,9 +211,10 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
   timecop
   turbolinks (~> 5)
+  twilio-ruby
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   1.15.3
+   1.15.4


### PR DESCRIPTION
# Versioning of Gemfile.lock
- Latest revision of lock file is upgraded and does not work with Heroku
- Cannot update [Heroku version of Bundler](https://devcenter.heroku.com/articles/bundler-version)
- Manually updated Gemfile.lock to be 1.15.2
- Other dependencies for other Gems (via Twilio) also installed.